### PR TITLE
Fixed logging role not able to proceed due to missing logging namespace

### DIFF
--- a/roles/logging/tasks/main.yaml
+++ b/roles/logging/tasks/main.yaml
@@ -9,6 +9,11 @@
     kind: IngressClass
   register: ingress_class
 
+- name: Create logging namespace
+  kubernetes.core.k8s:
+    kind: Namespace
+    name: logging
+
 - import_tasks: ./tasks/task-create-certificate.yaml
   vars:
     name: elasticsearch


### PR DESCRIPTION
- Fixed logging role not able to proceed due to missing logging namespace