### PR TITLE
Fix Helm installation and Metallb for Ingress

### DIFF
--- a/roles/ingress/tasks/configure-for-metallb.yaml
+++ b/roles/ingress/tasks/configure-for-metallb.yaml
@@ -7,7 +7,7 @@
 
 - name: Configure as Load-Balancer with Metallb
   vars:
-    ingress_host: "{{ ingress.metallb.hostname }}.{{ kube.cluster.domain }}"
+    ingress_host: "{{ in_ingress.metallb.hostname }}.{{ kube.cluster.domain }}"
     ingress_ip: "{{ ingress_service.resources[0].status.loadBalancer.ingress.0.ip }}"
   block:
     - name: Patch ingress controller service type to LoadBalancer
@@ -36,7 +36,7 @@
           ansible.builtin.include_role:
             name: infrastructure/dns/register
           vars:
-            server_name: "{{ ingress.metallb.hostname }}"
+            server_name: "{{ in_ingress.metallb.hostname }}"
             server_ip: "{{ ingress_ip }}"
 
       when: kube.cluster.use_dns_server

--- a/roles/kubernetes/cluster-node/tasks/ubuntu/install-helm.yaml
+++ b/roles/kubernetes/cluster-node/tasks/ubuntu/install-helm.yaml
@@ -9,7 +9,7 @@
   block:
     - name: Get helm gpg
       ansible.builtin.get_url:
-        url: https://baltocdn.com/helm/signing.asc
+        url: https://packages.buildkite.com/helm-linux/helm-debian/gpgkey
         dest: /tmp/helm.gpg
         mode: '0644'
         force: true
@@ -20,7 +20,7 @@
     - name: Register helm repository
       ansible.builtin.apt_repository:
         filename: helm
-        repo: "deb [arch=amd64 signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main"
+        repo: "deb [signed-by=/usr/share/keyrings/helm.gpg] https://packages.buildkite.com/helm-linux/helm-debian/any/ any main"
         update_cache: yes
 
     - name: Installing helm

--- a/roles/kubernetes/remote-admin/tasks/ubuntu/install-helm.yaml
+++ b/roles/kubernetes/remote-admin/tasks/ubuntu/install-helm.yaml
@@ -13,7 +13,8 @@
   block:
     - name: Get helm gpg
       ansible.builtin.get_url:
-        url: https://baltocdn.com/helm/signing.asc
+        # url: https://baltocdn.com/helm/signing.asc
+        url: https://packages.buildkite.com/helm-linux/helm-debian/gpgkey
         dest: /tmp/helm.gpg
         mode: '0644'
         force: true
@@ -24,7 +25,8 @@
     - name: Register helm repository
       ansible.builtin.apt_repository:
         filename: helm
-        repo: "deb [arch=amd64 signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main"
+        # repo: "deb [arch=amd64 signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main"
+        repo: "deb [signed-by=/usr/share/keyrings/helm.gpg] https://packages.buildkite.com/helm-linux/helm-debian/any/ any main"
         update_cache: yes
 
     - name: Installing helm


### PR DESCRIPTION
Fixed
- Helm installation failed due to URL changed
- Non-existence variable used in [configure-for-metallb.yaml](https://github.com/serenagrl/ansible-kubernetes/compare/regression-fix?expand=1#diff-59c3942d693ab10b2147d108d294e448751a0c33d7e3afa94d3f8ff3fd7141e0)